### PR TITLE
Update required node version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ These tools have been introduced by Adobe to document Adobe's Experience Data Mo
 ## Requirements
 
 - `npm` version 3.10.8 or up
-- `node` v10 or up
+- `node` v12 or up
 
 ## Example Output
 


### PR DESCRIPTION
Since 6298ed28, jsonschema2md requires node >= 12.0.0 (adobe#363).